### PR TITLE
Add Meta.choice_dependencies for cascading choices (metadata + valida…

### DIFF
--- a/dynamic_rest/fields/base.py
+++ b/dynamic_rest/fields/base.py
@@ -113,6 +113,8 @@ class DynamicField(fields.Field, DynamicBase):
         self.bound = False
         self.ui = kwargs.pop('ui', True)
         self.extra = kwargs.pop('extra', None)
+        self.choice_parent = kwargs.pop('choice_parent', None)
+        self.choice_mapping = kwargs.pop('choice_mapping', None)
         choices = kwargs.get('choices', None)
         if choices:
             self.choices = choices

--- a/dynamic_rest/metadata.py
+++ b/dynamic_rest/metadata.py
@@ -115,6 +115,9 @@ class DynamicMetadata(SimpleMetadata):
                     else field.choices
                 )
             ]
+        if getattr(field, 'choice_parent', None):
+            field_info['choice_parent'] = field.choice_parent
+            field_info['choice_mapping'] = getattr(field, 'choice_mapping', None)
         if hasattr(field, 'location'):
             field_info['location'] = field.location
         if hasattr(field, 'hide'):

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -256,6 +256,10 @@ class WithDynamicSerializerMixin(
         - read_only_fields - list of strings
         - untrimmed_fields - list of strings
         - depends - dict of dependency objects
+        - choice_dependencies - dict mapping field names to dependent choice config:
+            { "child_field": {"parent": "parent_field", "mapping": {parent_value: [allowed, ...]}} }
+            Used for cascading choice UIs (metadata exposes choice_parent + choice_mapping)
+            and server-side validation on create/update.
     """
 
     _ALL_FIELDS_CACHE = {}
@@ -989,6 +993,22 @@ class WithDynamicSerializerMixin(
         depends = getattr(meta, "depends", {})
         self.change_fields(fields, depends, "depends")
 
+        choice_dependencies = getattr(meta, "choice_dependencies", None) or {}
+        for dep_field, spec in choice_dependencies.items():
+            dep = fields.get(dep_field)
+            if not dep or not isinstance(spec, dict):
+                continue
+            parent = spec.get("parent")
+            mapping = spec.get("mapping")
+            if parent is None or mapping is None:
+                continue
+            dep.choice_parent = parent
+            dep.choice_mapping = mapping
+            kw = getattr(dep, "_kwargs", None) or getattr(dep, "kwargs", None)
+            if kw is not None:
+                kw["choice_parent"] = parent
+                kw["choice_mapping"] = mapping
+
     def _get_flagged_field_names(self, fields, attr, meta_attr=None):
         meta = self.get_meta()
         if meta_attr is None:
@@ -1424,6 +1444,49 @@ class WithDynamicSerializerMixin(
 
 class WithDynamicModelSerializerMixin(WithDynamicSerializerMixin):
     """Adds DREST serializer methods specific to model-based serializers."""
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        self._validate_choice_dependencies(attrs)
+        return attrs
+
+    def _effective_field_value(self, attrs, field_name):
+        if field_name in attrs:
+            return attrs[field_name]
+        inst = getattr(self, "instance", None)
+        if inst is not None:
+            return getattr(inst, field_name, None)
+        return None
+
+    def _validate_choice_dependencies(self, attrs):
+        choice_deps = getattr(self.Meta, "choice_dependencies", None) or {}
+        if not choice_deps:
+            return
+        for field_name, spec in choice_deps.items():
+            if not isinstance(spec, dict):
+                continue
+            parent_name = spec.get("parent")
+            mapping = spec.get("mapping")
+            if parent_name is None or mapping is None:
+                continue
+            value = self._effective_field_value(attrs, field_name)
+            if value in (None, ""):
+                continue
+            parent_val = self._effective_field_value(attrs, parent_name)
+            if parent_val in (None, ""):
+                raise serializers.ValidationError({
+                    parent_name: 'This field is required when "%s" is set.' % field_name
+                })
+            allowed = mapping.get(parent_val)
+            if allowed is None:
+                continue
+            if value not in allowed:
+                raise serializers.ValidationError({
+                    field_name: 'Invalid choice "%s" for the selected %s.' % (
+                        value,
+                        parent_name,
+                    )
+                })
 
     @classmethod
     def get_model(cls):

--- a/dynamic_rest/serializers.py
+++ b/dynamic_rest/serializers.py
@@ -257,7 +257,7 @@ class WithDynamicSerializerMixin(
         - untrimmed_fields - list of strings
         - depends - dict of dependency objects
         - choice_dependencies - dict mapping field names to dependent choice config:
-            { "child_field": {"parent": "parent_field", "mapping": {parent_value: [allowed, ...]}} }
+            { "child_field": {"parent_field": {parent_value: [allowed, ...]}} }
             Used for cascading choice UIs (metadata exposes choice_parent + choice_mapping)
             and server-side validation on create/update.
     """
@@ -998,8 +998,7 @@ class WithDynamicSerializerMixin(
             dep = fields.get(dep_field)
             if not dep or not isinstance(spec, dict):
                 continue
-            parent = spec.get("parent")
-            mapping = spec.get("mapping")
+            parent, mapping = self._normalize_choice_dependency_spec(spec)
             if parent is None or mapping is None:
                 continue
             dep.choice_parent = parent
@@ -1008,6 +1007,20 @@ class WithDynamicSerializerMixin(
             if kw is not None:
                 kw["choice_parent"] = parent
                 kw["choice_mapping"] = mapping
+
+    @staticmethod
+    def _normalize_choice_dependency_spec(spec):
+        """
+        Normalize a choice dependency spec to (parent_field_name, mapping).
+
+        Supported form:
+        - {"status": {<parent_value>: [<allowed_child_value>, ...]}}
+        """
+        # required: {"<parent_field>": {...}}
+        if len(spec) != 1:
+            return None, None
+        parent, mapping = next(iter(spec.items()))
+        return parent, mapping
 
     def _get_flagged_field_names(self, fields, attr, meta_attr=None):
         meta = self.get_meta()
@@ -1465,8 +1478,7 @@ class WithDynamicModelSerializerMixin(WithDynamicSerializerMixin):
         for field_name, spec in choice_deps.items():
             if not isinstance(spec, dict):
                 continue
-            parent_name = spec.get("parent")
-            mapping = spec.get("mapping")
+            parent_name, mapping = self._normalize_choice_dependency_spec(spec)
             if parent_name is None or mapping is None:
                 continue
             value = self._effective_field_value(attrs, field_name)

--- a/tests/test_choice_dependencies.py
+++ b/tests/test_choice_dependencies.py
@@ -1,0 +1,65 @@
+from django.test import TestCase
+from rest_framework import serializers
+
+from dynamic_rest.metadata import DynamicMetadata
+from dynamic_rest.serializers import DynamicModelSerializer
+from tests.models import User
+
+
+class CascadingChoiceSerializer(DynamicModelSerializer):
+    """
+    Test-only serializer: uses a real model, but adds two non-model fields
+    to validate cascading choice behavior.
+    """
+
+    status = serializers.ChoiceField(choices=(("a", "A"), ("b", "B")))
+    reason = serializers.ChoiceField(choices=(("r1", "R1"), ("r2", "R2")))
+
+    class Meta:
+        model = User
+        fields = ("id", "name", "last_name", "status", "reason")
+        choice_dependencies = {
+            "reason": {
+                "status": {
+                    "a": ["r1"],
+                    "b": ["r2"],
+                },
+            },
+        }
+
+
+class TestChoiceDependencies(TestCase):
+    def test_metadata_exposes_choice_parent_and_mapping(self):
+        serializer = CascadingChoiceSerializer()
+        reason_field = serializer.get_all_fields()["reason"]
+        info = DynamicMetadata().get_field_info(reason_field)
+
+        self.assertEqual(info.get("choice_parent"), "status")
+        self.assertEqual(
+            info.get("choice_mapping"),
+            {
+                "a": ["r1"],
+                "b": ["r2"],
+            },
+        )
+
+    def test_validation_allows_allowed_child_for_parent(self):
+        s = CascadingChoiceSerializer(
+            data={"name": "n", "last_name": "ln", "status": "a", "reason": "r1"}
+        )
+        self.assertTrue(s.is_valid(), s.errors)
+
+    def test_validation_rejects_disallowed_child_for_parent(self):
+        s = CascadingChoiceSerializer(
+            data={"name": "n", "last_name": "ln", "status": "a", "reason": "r2"}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("reason", s.errors)
+
+    def test_validation_requires_parent_when_child_is_set(self):
+        s = CascadingChoiceSerializer(
+            data={"name": "n", "last_name": "ln", "reason": "r1"}
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("status", s.errors)
+


### PR DESCRIPTION
…tion)

- Extend DynamicField with choice_parent and choice_mapping (popped from kwargs)
- Expose them in DynamicMetadata when choice_parent is set, for cascading UIs
- Apply Meta.choice_dependencies in setup_field to wire dependent fields
- Validate dependent choices in WithDynamicModelSerializerMixin.validate against parent value and mapping (skip when child is empty; require parent when child is set)