### PR TITLE
Add ephemeral resource filter metadata and viewset filtering support

### DIFF
--- a/dynamic_rest/ephemeral.py
+++ b/dynamic_rest/ephemeral.py
@@ -1,0 +1,83 @@
+"""Helpers for synthetic/ephemeral resource filtering metadata."""
+
+EPHEMERAL_FILTER_TYPE_OPERATORS = {
+    "boolean": {"eq", "in", "isnull"},
+    "date": {
+        "day",
+        "eq",
+        "gt",
+        "gte",
+        "in",
+        "isnull",
+        "lt",
+        "lte",
+        "month",
+        "range",
+        "week_day",
+        "year",
+    },
+    "datetime": {
+        "day",
+        "eq",
+        "gt",
+        "gte",
+        "in",
+        "isnull",
+        "lt",
+        "lte",
+        "month",
+        "range",
+        "week_day",
+        "year",
+    },
+    "decimal": {"eq", "gt", "gte", "in", "isnull", "lt", "lte", "range"},
+    "float": {"eq", "gt", "gte", "in", "isnull", "lt", "lte", "range"},
+    "integer": {"eq", "gt", "gte", "in", "isnull", "lt", "lte", "range"},
+    "string": {
+        "contains",
+        "endswith",
+        "eq",
+        "icontains",
+        "iendswith",
+        "in",
+        "isnull",
+        "istartswith",
+        "startswith",
+    },
+}
+
+
+def get_ephemeral_filter_fields(serializer_or_class):
+    meta = getattr(serializer_or_class, "Meta", None)
+    if meta is None and not isinstance(serializer_or_class, type):
+        meta = getattr(serializer_or_class.__class__, "Meta", None)
+    return getattr(meta, "filter_fields", {})
+
+
+def normalize_ephemeral_filter_field(field_name, filter_fields):
+    field_config = filter_fields[field_name]
+    operators = None
+
+    if isinstance(field_config, str):
+        queryset_field = field_config
+        field_type = "string"
+    elif isinstance(field_config, dict):
+        queryset_field = field_config.get("source", field_name)
+        field_type = field_config.get("type", "string")
+        operators = field_config.get("operators")
+    else:
+        queryset_field = field_config[0]
+        field_type = field_config[1]
+        if len(field_config) > 2:
+            operators = field_config[2]
+
+    return queryset_field, field_type, operators
+
+
+def get_ephemeral_filter_operators(field_type, operators=None):
+    if operators is not None:
+        return set(operators)
+    return EPHEMERAL_FILTER_TYPE_OPERATORS.get(
+        field_type,
+        EPHEMERAL_FILTER_TYPE_OPERATORS["string"],
+    )

--- a/dynamic_rest/metadata.py
+++ b/dynamic_rest/metadata.py
@@ -5,6 +5,11 @@ from rest_framework.fields import empty
 from rest_framework.metadata import SimpleMetadata
 from rest_framework.serializers import ListSerializer, ModelSerializer
 
+from dynamic_rest.ephemeral import (
+    get_ephemeral_filter_fields,
+    get_ephemeral_filter_operators,
+    normalize_ephemeral_filter_field,
+)
 from dynamic_rest.fields import DynamicRelationField, DynamicJSONField, DynamicLinkField
 from dynamic_rest.utils import urljoin
 
@@ -49,6 +54,7 @@ class DynamicMetadata(SimpleMetadata):
             if hasattr(serializer, 'get_plural_name'):
                 metadata['name'] = serializer.get_plural_name()
             metadata['fields'] = self.get_serializer_info(serializer)
+            self.apply_ephemeral_filter_metadata(serializer, metadata['fields'])
             metadata['icon'] = serializer.get_icon()
             metadata['search_key'] = serializer.get_search_key()
             metadata['style'] = serializer.get_style()
@@ -76,6 +82,36 @@ class DynamicMetadata(SimpleMetadata):
             metadata['url'] = view._router.base_url
 
         return metadata
+
+    def apply_ephemeral_filter_metadata(self, serializer, fields):
+        filter_fields = get_ephemeral_filter_fields(serializer)
+        get_model = getattr(serializer, 'get_model', None)
+        is_ephemeral = get_model and get_model() is None
+
+        if not filter_fields and not is_ephemeral:
+            return fields
+
+        for field_name, field_info in fields.items():
+            if is_ephemeral:
+                if field_info.get('ui') is None:
+                    field_info['ui'] = True
+                field_info['filterable'] = False
+                field_info['sortable'] = False
+
+            if field_name not in filter_fields:
+                continue
+
+            _queryset_field, field_type, operators = normalize_ephemeral_filter_field(
+                field_name,
+                filter_fields,
+            )
+            field_info['filterable'] = True
+            field_info['filter_type'] = field_type
+            field_info['filter_operators'] = sorted(
+                get_ephemeral_filter_operators(field_type, operators)
+            )
+
+        return fields
 
     def get_field_info(self, field):
         """Adds to the metadata response."""

--- a/dynamic_rest/viewsets.py
+++ b/dynamic_rest/viewsets.py
@@ -3,7 +3,8 @@ import csv
 import re
 import json
 import operator as op
-from decimal import Decimal
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
 import statistics
 
 from io import StringIO
@@ -15,11 +16,17 @@ from django.db.models.functions import (
     Trunc, Length, Lower, Upper, Cast
 )
 from django.db import models
+from django.utils.dateparse import parse_date, parse_datetime
 from rest_framework import exceptions, status, viewsets
 from rest_framework.mixins import ListModelMixin
 from rest_framework.response import Response
 from rest_framework.request import is_form_media_type
 
+from dynamic_rest.ephemeral import (
+    EPHEMERAL_FILTER_TYPE_OPERATORS,
+    get_ephemeral_filter_fields,
+    normalize_ephemeral_filter_field,
+)
 from dynamic_rest.permissions import PermissionsViewSetMixin
 from dynamic_rest.conf import settings
 from dynamic_rest.filters import DynamicFilterBackend, DynamicSortingFilter
@@ -1217,7 +1224,279 @@ class WithDynamicViewSetBase(object):
         return viewset.list(request)
 
 
-class WithDynamicViewSetMixin(PermissionsViewSetMixin, WithDynamicViewSetBase):
+class EphemeralFilterMixin(object):
+    ephemeral_filter_fields = None
+    ephemeral_filter_type_operators = EPHEMERAL_FILTER_TYPE_OPERATORS
+
+    def get_ephemeral_filter_fields(self):
+        if self.ephemeral_filter_fields is not None:
+            return self.ephemeral_filter_fields
+
+        return get_ephemeral_filter_fields(self.get_serializer_class())
+
+    def get_ephemeral_base_queryset(self, queryset=None):
+        if queryset is None:
+            queryset = getattr(self, 'queryset', None)
+            if queryset is not None:
+                queryset = queryset.all()
+            else:
+                queryset = self.model.objects.all()
+
+        permissions = getattr(self, 'permissions', None)
+        if not permissions:
+            return queryset
+
+        access = permissions.list
+        if access.full_access:
+            return queryset
+        if access.no_access:
+            return queryset.none()
+        return queryset.filter(access.filters)
+
+    def filter_ephemeral_queryset(self, queryset, request=None, filter_fields=None):
+        request = request or self.request
+        if filter_fields is None:
+            filter_fields = self.get_ephemeral_filter_fields()
+        filter_specs = self._get_ephemeral_filter_specs(request)
+        query = None
+        combine_with_or = request.query_params.get('filter', 'and').lower() in {
+            'or',
+            '|',
+        }
+
+        for key, values in filter_specs:
+            next_query = self._build_ephemeral_filter(key, values, filter_fields)
+            if query is None:
+                query = next_query
+            elif combine_with_or:
+                query |= next_query
+            else:
+                query &= next_query
+
+        return queryset.filter(query) if query is not None else queryset
+
+    def get_ephemeral_resource_metadata(self, serializer_class=None):
+        serializer_class = serializer_class or self.get_serializer_class()
+        serializer = serializer_class(for_metadata=True)
+        metadata = self.metadata_class()
+        fields = metadata.get_serializer_info(serializer)
+        metadata.apply_ephemeral_filter_metadata(serializer, fields)
+
+        permissions = {'read': True}
+        if getattr(self, 'request', None) is not None:
+            full_permissions = getattr(self, 'full_permissions', None)
+            if full_permissions:
+                permissions = full_permissions.serialize()
+        permissions['fields'] = serializer.get_field_permissions()
+        try:
+            id_field = serializer.get_pk_field()
+        except exceptions.APIException:
+            id_field = 'pk'
+
+        return {
+            'fields': fields,
+            'icon': serializer.get_icon(),
+            'description': serializer.get_description(),
+            'sections': [
+                section.serialize() for section in serializer.get_sections()
+            ],
+            'id_field': id_field,
+            'name_field': serializer.get_name_field(),
+            'permissions': permissions,
+        }
+
+    def _get_ephemeral_filter_specs(self, request):
+        if request is getattr(self, 'request', None):
+            return list(self.get_request_feature(self.FILTER).items())
+
+        original_request = getattr(self, 'request', None)
+        self.request = request
+        try:
+            return list(self.get_request_feature(self.FILTER).items())
+        finally:
+            self.request = original_request
+
+    def _normalize_ephemeral_filter_field(self, field_name, filter_fields):
+        try:
+            queryset_field, field_type, operators = normalize_ephemeral_filter_field(
+                field_name,
+                filter_fields,
+            )
+        except KeyError:
+            raise exceptions.ParseError(
+                '"%s" is not a filterable synthetic resource field.' % field_name
+            )
+        except (IndexError, TypeError, ValueError):
+            raise exceptions.ParseError(
+                '"%s" has an invalid synthetic filter configuration.' % field_name
+            )
+        return queryset_field, field_type, operators
+
+    def _parse_ephemeral_filter_key(self, key, filter_fields):
+        if not key:
+            raise exceptions.ParseError('Synthetic resource filter key cannot be empty.')
+
+        exclude = key.startswith('-')
+        if exclude:
+            key = key[1:]
+
+        valid_operators = {
+            op for op in DynamicFilterBackend.VALID_FILTER_OPERATORS if op
+        }
+        parts = key.split('.')
+        operator = 'eq'
+        if len(parts) > 1 and parts[-1] in valid_operators:
+            operator = parts.pop()
+
+        field = '.'.join(parts)
+        queryset_field, field_type, operators = self._normalize_ephemeral_filter_field(
+            field, filter_fields
+        )
+        supported_operators = (
+            set(operators)
+            if operators is not None
+            else self.ephemeral_filter_type_operators.get(
+                field_type,
+                self.ephemeral_filter_type_operators['string'],
+            )
+        )
+        if operator not in supported_operators:
+            raise exceptions.ParseError(
+                '"%s" does not support the "%s" filter operator.'
+                % (field, operator)
+            )
+
+        return exclude, queryset_field, field_type, operator
+
+    def _normalize_ephemeral_filter_values(self, values, operator):
+        if not isinstance(values, (list, tuple)):
+            values = [values]
+
+        normalized = []
+        for value in values:
+            if operator in {'in', 'range'} and isinstance(value, str) and ',' in value:
+                normalized.extend(v.strip() for v in value.split(','))
+            else:
+                normalized.append(value)
+        return normalized
+
+    def _coerce_ephemeral_filter_value(self, value, field_type, operator=None):
+        if operator == 'isnull':
+            return is_truthy(value)
+
+        if operator in {'day', 'month', 'week_day', 'year'}:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                raise exceptions.ParseError(
+                    '"%s" must be an integer for the "%s" filter operator.'
+                    % (value, operator)
+                )
+
+        if field_type == 'boolean':
+            return is_truthy(value)
+
+        if field_type == 'date':
+            if isinstance(value, datetime):
+                return value.date()
+            if isinstance(value, date):
+                return value
+
+            parsed_value = parse_date(str(value))
+            if parsed_value is None:
+                parsed_datetime = parse_datetime(str(value))
+                parsed_value = parsed_datetime.date() if parsed_datetime else None
+            if parsed_value is None:
+                raise exceptions.ParseError(
+                    '"%s" is not a valid date filter value.' % value
+                )
+            return parsed_value
+
+        if field_type == 'datetime':
+            if isinstance(value, datetime):
+                return value
+
+            parsed_value = parse_datetime(str(value))
+            if parsed_value is None:
+                raise exceptions.ParseError(
+                    '"%s" is not a valid datetime filter value.' % value
+                )
+            return parsed_value
+
+        if field_type == 'decimal':
+            try:
+                return Decimal(str(value))
+            except (InvalidOperation, TypeError, ValueError):
+                raise exceptions.ParseError(
+                    '"%s" is not a valid decimal filter value.' % value
+                )
+
+        if field_type == 'integer':
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                raise exceptions.ParseError(
+                    '"%s" is not a valid integer filter value.' % value
+                )
+
+        if field_type == 'float':
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                raise exceptions.ParseError(
+                    '"%s" is not a valid numeric filter value.' % value
+                )
+
+        return value
+
+    def _build_ephemeral_filter(self, key, values, filter_fields):
+        exclude, queryset_field, field_type, operator = self._parse_ephemeral_filter_key(
+            key, filter_fields
+        )
+        values = self._normalize_ephemeral_filter_values(values, operator)
+        if not values:
+            raise exceptions.ParseError('"%s" requires a filter value.' % key)
+
+        if operator == 'range':
+            if len(values) < 2:
+                raise exceptions.ParseError(
+                    '"%s.range" requires two filter values.' % key
+                )
+            if values[0] in ('', None):
+                operator = 'lte'
+                value = self._coerce_ephemeral_filter_value(
+                    values[1], field_type, operator
+                )
+            elif values[1] in ('', None):
+                operator = 'gte'
+                value = self._coerce_ephemeral_filter_value(
+                    values[0], field_type, operator
+                )
+            else:
+                value = [
+                    self._coerce_ephemeral_filter_value(item, field_type, operator)
+                    for item in values[:2]
+                ]
+        elif operator == 'in':
+            value = [
+                self._coerce_ephemeral_filter_value(item, field_type, operator)
+                for item in values
+                if item not in ('', None)
+            ]
+        else:
+            value = self._coerce_ephemeral_filter_value(
+                values[0], field_type, operator
+            )
+
+        lookup = queryset_field if operator == 'eq' else '%s__%s' % (
+            queryset_field,
+            operator,
+        )
+        query = Q(**{lookup: value})
+        return ~query if exclude else query
+
+
+class WithDynamicViewSetMixin(PermissionsViewSetMixin, WithDynamicViewSetBase, EphemeralFilterMixin):
     pass
 
 

--- a/tests/test_ephemeral_filters.py
+++ b/tests/test_ephemeral_filters.py
@@ -1,0 +1,104 @@
+from datetime import date
+
+from django.http import QueryDict
+from django.test import SimpleTestCase
+from rest_framework import exceptions
+
+from dynamic_rest import fields
+from dynamic_rest.serializers import DynamicEphemeralSerializer
+from dynamic_rest.viewsets import DynamicModelViewSet
+
+
+class SyntheticReportSerializer(DynamicEphemeralSerializer):
+    class Meta:
+        name = 'synthetic_report'
+        fields = (
+            'pk',
+            'cohort_month',
+            'cases_assigned',
+            'officer_name',
+            'unfilterable',
+        )
+        filter_fields = {
+            'cohort_month': ('cohort_month_date', 'date'),
+            'cases_assigned': ('cases_assigned', 'integer'),
+            'officer_name': ('officer_name', 'string'),
+        }
+
+    pk = fields.DynamicCharField(read_only=True)
+    cohort_month = fields.DynamicDateField(read_only=True)
+    cases_assigned = fields.DynamicIntegerField(read_only=True)
+    officer_name = fields.DynamicCharField(read_only=True)
+    unfilterable = fields.DynamicCharField(read_only=True)
+
+
+class SyntheticReportViewSet(DynamicModelViewSet):
+    serializer_class = SyntheticReportSerializer
+
+
+class TestEphemeralFilterMixin(SimpleTestCase):
+    def get_view(self, query_string=''):
+        request = type(
+            'Request',
+            (),
+            {'query_params': QueryDict(query_string)},
+        )()
+        view = SyntheticReportViewSet()
+        view.request = request
+        return view, request
+
+    def test_builds_filters_for_ephemeral_aliases(self):
+        view, request = self.get_view(
+            'filter%7Bcohort_month%7D=2026-01-01'
+            '&filter%7Bcases_assigned.gte%7D=2'
+        )
+        filter_fields = view.get_ephemeral_filter_fields()
+        specs = view._get_ephemeral_filter_specs(request)
+
+        self.assertEqual(
+            view._build_ephemeral_filter(*specs[0], filter_fields).children,
+            [('cohort_month_date', date(2026, 1, 1))],
+        )
+        self.assertEqual(
+            view._build_ephemeral_filter(*specs[1], filter_fields).children,
+            [('cases_assigned__gte', 2)],
+        )
+
+    def test_keeps_comma_in_string_equality_filter(self):
+        view, request = self.get_view(
+            'filter%7Bofficer_name%7D=Doe%2C%20Jane'
+        )
+        specs = view._get_ephemeral_filter_specs(request)
+
+        self.assertEqual(
+            view._build_ephemeral_filter(
+                *specs[0], view.get_ephemeral_filter_fields()
+            ).children,
+            [('officer_name', 'Doe, Jane')],
+        )
+
+    def test_rejects_unknown_ephemeral_filter_fields(self):
+        view, request = self.get_view('filter%7Bmissing_field%7D=value')
+        specs = view._get_ephemeral_filter_specs(request)
+
+        with self.assertRaises(exceptions.ParseError):
+            view._build_ephemeral_filter(
+                *specs[0],
+                view.get_ephemeral_filter_fields(),
+            )
+
+    def test_ephemeral_metadata_uses_filter_fields(self):
+        view, _request = self.get_view()
+        metadata = view.get_ephemeral_resource_metadata(SyntheticReportSerializer)
+        fields_metadata = metadata['fields']
+        field_permissions = metadata['permissions']['fields']
+
+        self.assertTrue(fields_metadata['cohort_month']['filterable'])
+        self.assertEqual(fields_metadata['cohort_month']['filter_type'], 'date')
+        self.assertIn('gte', fields_metadata['cohort_month']['filter_operators'])
+        self.assertTrue(fields_metadata['cases_assigned']['filterable'])
+        self.assertFalse(fields_metadata['unfilterable']['filterable'])
+        self.assertFalse(fields_metadata['unfilterable']['sortable'])
+        for field_name, field_metadata in fields_metadata.items():
+            self.assertTrue(field_metadata['ui'], field_name)
+            self.assertTrue(field_permissions[field_name]['read'], field_name)


### PR DESCRIPTION
Extend metadata generation to expose ephemeral filter field types and operators. Introduce EphemeralFilterMixin for synthetic resource filter parsing, coercion, and queryset construction. Support permission-aware base queryset handling and ephemeral resource metadata serialization.